### PR TITLE
Add online user counter in footer

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -522,7 +522,17 @@ footer{
 }
 .footer-social-icons{
     display: flex;
-    gap: 30px;   
+    gap: 30px;
+}
+.online-users{
+    font-size: 14px;
+    margin-top: 10px;
+    color: var(--text-color-second);
+    text-align: center;
+}
+.online-users span{
+    font-weight: 600;
+    color: var(--text-color-third);
 }
 .bottom-footer{
     font-size: 14px;

--- a/assets/js/online-count.js
+++ b/assets/js/online-count.js
@@ -1,0 +1,28 @@
+const NAMESPACE = 'septiantoriski_github_io';
+const KEY = 'online_users';
+
+function getCount() {
+    fetch(`https://api.countapi.xyz/get/${NAMESPACE}/${KEY}`)
+        .then(res => res.json())
+        .then(data => {
+            const el = document.getElementById('online-users-count');
+            if (el) {
+                el.textContent = data.value;
+            }
+        })
+        .catch(err => console.error('Failed to fetch online users', err));
+}
+
+function initCounter() {
+    fetch(`https://api.countapi.xyz/update/${NAMESPACE}/${KEY}?amount=1`)
+        .then(getCount)
+        .catch(err => console.error('Failed to update online users', err));
+}
+
+initCounter();
+setInterval(getCount, 5000);
+
+window.addEventListener('beforeunload', () => {
+    navigator.sendBeacon(`https://api.countapi.xyz/update/${NAMESPACE}/${KEY}?amount=-1`);
+});
+

--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
                 </li>
             </ul>
         </div>
-       <div class="footer-social-icons">
+        <div class="footer-social-icons">
     <div class="icon">
         <a href="https://www.instagram.com/rspto_?utm_source=qr&igsh=MWRyZHZ4OHRmMG4zeQ==" target="_blank">
             <i class="uil uil-instagram"></i>
@@ -271,6 +271,10 @@
     </div>
 </div>
 
+        <div id="online-counter" class="online-users">
+            <span id="online-users-count">0</span> Pengguna Online
+        </div>
+
         <div class="bottom-footer">
             <p>Copyright &copy; <a href="#home" style="text-decoration: none;">Riski Septianto</a> - All rights reserved</p>
         </div>
@@ -282,5 +286,6 @@
     <script src="https://unpkg.com/typed.js@2.0.16/dist/typed.umd.js"></script>
     <script src="https://unpkg.com/scrollreveal"></script>
     <script src="assets/js/main.js"></script>
+    <script src="assets/js/online-count.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Show current visitors with a new online user counter in the footer using CountAPI.
- Style the counter for seamless integration with existing footer theme.
- Add a lightweight script that updates and maintains the online user count.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68971c07b0ac832786809c711cd2f07b